### PR TITLE
Define multiple entry points

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -1,9 +1,3 @@
-// styles
-import './css/browser.css';
-import 'angular-tree-control/css/tree-control.css';
-import 'angular-tree-control/css/tree-control-attribute.css';
-// import 'bootstrap/dist/css/bootstrap.css';
-
 import angular from 'angular';
 import 'angular-tree-control';
 // FIXME: doing this clashes with the dashboard's global bootstrap;

--- a/app/embeddable.entry.js
+++ b/app/embeddable.entry.js
@@ -1,0 +1,7 @@
+// styles
+import './css/browser.css';
+import 'angular-tree-control/css/tree-control.css';
+import 'angular-tree-control/css/tree-control-attribute.css';
+
+// Finally, import the main entry point
+import './app.js';

--- a/app/standalone.entry.js
+++ b/app/standalone.entry.js
@@ -1,0 +1,8 @@
+// styles
+import './css/browser.css';
+import 'angular-tree-control/css/tree-control.css';
+import 'angular-tree-control/css/tree-control-attribute.css';
+import 'bootstrap/dist/css/bootstrap.css';
+
+// Finally, import the main entry point
+import './app.js';

--- a/package.json
+++ b/package.json
@@ -19,13 +19,14 @@
     "karma-jasmine": "^0.3.6",
     "karma-junit-reporter": "^0.2.2",
     "karma-webpack": "^1.7.0",
+    "ng-cache-loader": "0.0.15",
     "shelljs": "^0.2.6",
     "style-loader": "^0.13.0",
     "url-loader": "^0.5.7",
     "webpack": "^1.12.9"
   },
   "scripts": {
-    "prepublish": "webpack --progress --colors",
+    "prepublish": "webpack --progress --colors --entry ./embeddable.entry.js",
     "prestart": "npm install",
     "start": "http-server -a localhost -p 8000 -c-1",
     "pretest": "npm install",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,7 +5,6 @@ var APP = __dirname + '/app';
 
 module.exports = {
   context: APP,
-  entry: './app.js',
   output: {
     path: APP,
     filename: 'transfer_browse.js',


### PR DESCRIPTION
Add an 'embedded' entry point that omits external libraries that might conflict, and a 'standalone' entry point that includes them.  Move style imports to the entry points so that app.jso is importable as a module outside webpack.

See also artefactual-labs/appraisal-tab#140
