### PR TITLE
Browser: Fix DSpace transfer to accept zip files or directories

### DIFF
--- a/app/browse/browse.controller.js
+++ b/app/browse/browse.controller.js
@@ -63,11 +63,25 @@ class BrowseController {
     });
   }
 
+  zip_filter(file) {
+      // Check if it's a compressed file
+      if (
+        file.title.endsWith('.zip') ||
+        file.title.endsWith('.tgz') ||
+        file.title.endsWith('.tar.gz')
+      ) {
+          return true;
+      }
+      return false;
+    }
+
   // Determines whether a given file can be added to the transfer,
   // depending on the transfer type.
   file_can_be_added(file) {
     if (this.transfer.type === 'zipped bag') {
-      return !file.directory && (file.title.endsWith('.zip') || file.title.endsWith('.tgz') || file.title.endsWith('.tar.gz'));
+      return !file.directory && this.zip_filter(file);
+    } else if (this.transfer.type === 'dspace') {
+      return file.directory || this.zip_filter(file);
     } else {
       return file.directory;
     }


### PR DESCRIPTION
DSpace transfer accepts compressed files or directories. Fix regression in transfer-browser to allow zip files to be selected.